### PR TITLE
Fixes issue with comma in Wordle number

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")
-rex = re.compile(r'Wordle [0-9]{3,}')
+rex = re.compile(r'Wordle [0-9,]{3,}')
 botrex = re.compile(r'WordleBot\nSkill')
 fivegreens = "🟩🟩🟩🟩🟩"
 padline = "❌❌❌❌❌"


### PR DESCRIPTION
Makes comma a valid character in the Wordle regex which started failing when Wordle 1000 came out as `Wordle 1,000`
